### PR TITLE
Utilizes local storage for initial 'hot startups' company seed

### DIFF
--- a/client/www/js/auth_controller.js
+++ b/client/www/js/auth_controller.js
@@ -1,10 +1,14 @@
 angular.module('upstarter.auth.controllers', [])
 
-.controller("LoginCtrl", ["$scope", "$rootScope", '$location', '$window', '$http', 'Authenticate', '$cookieStore', function($scope, $rootScope, $location, $window, $http, Authenticate, $cookieStore) {
+.controller("LoginCtrl", ["$scope", "$rootScope", '$location', '$window', '$http', 'Authenticate', '$cookieStore', 'InitialSeed', function($scope, $rootScope, $location, $window, $http, Authenticate, $cookieStore, InitialSeed) {
 
     $scope.login = function(){
       $window.location.href = 'http://upstarter-server.herokuapp.com/auth/linkedin';
     }
+
+    InitialSeed.then(function(data){
+      window.localStorage["initialSeed"] = JSON.stringify(data)
+    });
 
     $scope.logout = function() {
       document.cookie = 'token=; Max-Age=0'

--- a/client/www/js/controllers.js
+++ b/client/www/js/controllers.js
@@ -134,10 +134,8 @@ angular.module('upstarter.controllers', [])
       }, 400);
     };
 
-    InitialSeed.then(function(data){
-      $scope.startups = data;
+    $scope.startups = JSON.parse(localStorage["initialSeed"]);
       // console.log(data)
-    });
     // // cities - filter radius instead
 
     // $scope.colorScore = colorScore.colorScore

--- a/client/www/templates/search.html
+++ b/client/www/templates/search.html
@@ -79,7 +79,7 @@
           <div class="company-info item-text-wrap">
             <div ng-if="startup.headquarters.length == 1"   class="company-info-tidbit">{{startup.headquarters[0].city}}, {{startup.headquarters[0].country}}</div>
 
-            <div ng-if="(!startup.headquarters || startup.headquarters.length == 0) && (startup.offices.length > 0" class="company-info-tidbit">{{startup.offices[0].city}}, {{startup.offices[0].country}}</div>
+            <div ng-if="(!startup.headquarters || startup.headquarters.length == 0) && (startup.offices.length > 0)" class="company-info-tidbit">{{startup.offices[0].city}}, {{startup.offices[0].country}}</div>
 
             <div ng-if="(startup.headquarters.length == 0 || !startup.headquarters) && (startup.offices.length == 0 || !startup.offices)" class="company-info-tidbit">No Location Data</div>
 


### PR DESCRIPTION
Hi all — 

This request moves the initial seed function from the search controller (to be executed when the initial company page loads) to the login controller (to be executed on the login splash page). The startups are now loaded from local storage instead of an AJAX request, making them ready the moment the search page loads. I tested the performance of this feature branch, and it is noticeably quicker than the master branch, as there's no lag loading the startup listings anymore. It also corrects a pesky HTML typo that I take the blame for :)
